### PR TITLE
Feature/jwt 인증과 인가 설정

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -21,12 +21,15 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'warn',
     'prettier/prettier': [
       'error',
       {
         endOfLine: 'auto',
         singleQuote: true,
       },
+      // Note: you must disable the base rule as it can report incorrect errors
     ],
   },
 };

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,15 +7,17 @@ import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
 import { AnalyticsModule } from './analytics/analytics.module';
+
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import postgresConfig from './config/postgres.config';
 import jwtConfig from './config/jwt.config';
+import envConfig from './config/env.config';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [postgresConfig, jwtConfig],
+      load: [postgresConfig, jwtConfig, envConfig],
     }),
     TypeOrmModule.forRootAsync({
       inject: [ConfigService],
@@ -30,7 +32,7 @@ import jwtConfig from './config/jwt.config';
           autoLoadEntities: true,
         };
         // 주의! development 환경에서만 db 활용
-        if (configService.get('NODE_ENV') === 'development') {
+        if (configService.get('ENVIRONMENT') === 'development') {
           console.info('Sync TypeORM');
           obj = Object.assign(obj, {
             synchronize: true,

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -29,7 +29,7 @@ import jwtConfig from './config/jwt.config';
           password: configService.get('postgres.password'),
           autoLoadEntities: true,
         };
-        // 주의! development 환경에서만 개발 편의성을 위해 활용
+        // 주의! development 환경에서만 db 활용
         if (configService.get('NODE_ENV') === 'development') {
           console.info('Sync TypeORM');
           obj = Object.assign(obj, {

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -10,12 +10,14 @@ import { JwtStrategy } from './jwt.strategy';
 import { JwtAuthGuard } from './jwt-auth.guard';
 import { APP_GUARD } from '@nestjs/core';
 import { ConfigService } from '@nestjs/config';
+import { RefreshToken } from '@/entity/refresh-token.entity';
 
 @Module({
   imports: [
     UserModule,
     PassportModule,
     TypeOrmModule.forFeature([User]),
+    TypeOrmModule.forFeature([RefreshToken]),
     JwtModule.registerAsync({
       inject: [ConfigService],
       useFactory: async (

--- a/backend/src/auth/dto/res.dto.ts
+++ b/backend/src/auth/dto/res.dto.ts
@@ -1,11 +1,22 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class SigninResDto {
-  @ApiProperty({ required: true })
-  accessToken: string;
-}
-
 export class SignupResDto {
   @ApiProperty({ required: true })
   id: string;
+}
+
+export class SigninResDto {
+  @ApiProperty({ required: true })
+  accessToken: string;
+
+  @ApiProperty({ required: true })
+  refreshToken: string;
+}
+
+export class RefreshResDto {
+  @ApiProperty({ required: true })
+  accessToken: string;
+
+  @ApiProperty({ required: true })
+  refreshToken: string;
 }

--- a/backend/src/auth/jwt-auth.guard.ts
+++ b/backend/src/auth/jwt-auth.guard.ts
@@ -1,11 +1,20 @@
-import { ExecutionContext, Injectable } from '@nestjs/common';
+import {
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
 import { AuthGuard } from '@nestjs/passport';
+import { Request } from 'express';
 import { IS_PUBLIC_KEY } from 'src/common/decorator/public.decorator';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
-  constructor(private reflector: Reflector) {
+  constructor(
+    private reflector: Reflector,
+    private jwtService: JwtService,
+  ) {
     super();
   }
 
@@ -14,9 +23,22 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       context.getHandler(),
       context.getClass(),
     ]);
+
     if (isPublic) {
       return true;
     }
+
+    const http = context.switchToHttp();
+    const { url, headers } = http.getRequest<Request>();
+    const token = headers.authorization?.split(' ')[1];
+    const decoded = this.jwtService.decode(token);
+
+    // refresh route 외에 refresh Token 으로 요청 시 에러 처리
+    if (url !== '/api/auth/refresh' && decoded['tokenType'] === 'refresh') {
+      console.error('Access Token is required');
+      throw new UnauthorizedException();
+    }
+
     return super.canActivate(context);
   }
 }

--- a/backend/src/common/decorator/role.decorator.ts
+++ b/backend/src/common/decorator/role.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '@/user/enum/user.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/backend/src/config/env.config.ts
+++ b/backend/src/config/env.config.ts
@@ -1,0 +1,5 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('env', () => ({
+  secret: process.env.ENVIRONMENT || 'development',
+}));

--- a/backend/src/entity/refresh-token.entity.ts
+++ b/backend/src/entity/refresh-token.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+
+@Entity()
+export class RefreshToken {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  token: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updateAt: Date;
+
+  @OneToOne(() => User, (user) => user.refreshToken)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+}

--- a/backend/src/entity/user.entity.ts
+++ b/backend/src/entity/user.entity.ts
@@ -1,10 +1,17 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
-import { Board } from './board.entity';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  OneToOne,
+} from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
+import { Board } from './board.entity';
+import { RefreshToken } from './refresh-token.entity';
 
-@Entity({ name: 'user' })
+@Entity()
 export class User {
-  // @PrimaryColumn('uuid', { default: uuidv4() }) // 기본값으로 UUID를 생성
+  // @PrimaryColumn('uuid', { default: uuid v4() }) // 기본값으로 UUID를 생성
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
@@ -39,4 +46,7 @@ export class User {
   // Board와의 One-to-Many 관계 설정
   @OneToMany(() => Board, (board) => board.user)
   boards: Board[]; // User 엔티티와의 관계를 나타내는 필드
+
+  @OneToOne(() => RefreshToken, (refreshToken) => refreshToken.user)
+  refreshToken: RefreshToken;
 }

--- a/backend/src/entity/user.entity.ts
+++ b/backend/src/entity/user.entity.ts
@@ -8,6 +8,7 @@ import {
 import { ApiProperty } from '@nestjs/swagger';
 import { Board } from './board.entity';
 import { RefreshToken } from './refresh-token.entity';
+import { Role } from '@/user/enum/user.enum';
 
 @Entity()
 export class User {
@@ -26,6 +27,9 @@ export class User {
   @ApiProperty({ description: '비밀번호' })
   @Column()
   password: string;
+
+  @Column({ type: 'enum', enum: Role })
+  role: Role = Role.User; // 기본값으로 USER를 할당
 
   @ApiProperty({ description: '이메일 인증 여부' })
   @Column({ default: false })

--- a/backend/src/user/enum/user.enum.ts
+++ b/backend/src/user/enum/user.enum.ts
@@ -1,0 +1,4 @@
+export enum Role {
+  Admin = 'ADMIN',
+  User = 'USER',
+}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,15 +1,26 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { ApiBearerAuth, ApiExtraModels, ApiTags } from '@nestjs/swagger';
 import { UserService } from './user.service';
 import { ApiGetResponse } from '@/common/decorator/swagger.decorator';
 import { FindUserResDto } from './dto/res.dto';
 import { User, UserAfterAuth } from '@/common/decorator/user.decorator';
+import { PageReqDto } from '@/common/dto/req.dto';
+import { Roles } from '@/common/decorator/role.decorator';
+import { Role } from './enum/user.enum';
 
 @ApiTags('User')
 @ApiExtraModels(FindUserResDto)
 @Controller('api/users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
+
+  @ApiBearerAuth()
+  @ApiGetResponse(FindUserResDto)
+  @Roles(Role.Admin)
+  @Get()
+  findAll(@Query() { page }: PageReqDto, @User() user: UserAfterAuth) {
+    return this.userService.findAll();
+  }
 
   @ApiBearerAuth()
   @ApiGetResponse(FindUserResDto)

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -2,6 +2,7 @@ import { User } from '@/entity/user.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { Role } from './enum/user.enum';
 
 @Injectable()
 export class UserService {
@@ -20,6 +21,11 @@ export class UserService {
     return user;
   }
 
+  async findAll() {
+    const users = await this.userRepository.find();
+    return users;
+  }
+
   async findOne(id: string) {
     const user = await this.userRepository.findOneBy({ id });
     return user;
@@ -28,5 +34,10 @@ export class UserService {
   async findOneByEmail(email: string) {
     const user = await this.userRepository.findOneBy({ email });
     return user;
+  }
+
+  async checkUserIsAdmin(userId: string) {
+    const user = await this.userRepository.findOneBy({ id: userId });
+    return user.role === Role.Admin;
   }
 }


### PR DESCRIPTION
- refresh-token을 위한 entitiy 생성으로 refresh token 발급 로직 추가했습니다.
- refresh 컨트롤러 서비스 생성했습니다.
- jwt-auth.guard에서 accesstoken으로만 올 때 검증을 하도록 했습니다.
- user.entity에 role 컬럼 생성 및 타입을 enum으로 USER, ADMIN을 설정했습니다.
- Roles 데코레이터를 통해서 Roles데코레이터 role을 넣은 값에 따라 인가 설정을 했습니다.